### PR TITLE
Update pre-commit configuration and dependencies

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -31,6 +31,7 @@ exclude .gitignore
 exclude .gitmodules
 exclude .ipynb_checkpoints
 exclude .markdownlint.json
+exclude .pre-commit-config.yml
 exclude .DS_Store
 exclude CHANGELOG.md
 exclude environment.yml

--- a/requirements/requirements.dev.txt
+++ b/requirements/requirements.dev.txt
@@ -2,4 +2,5 @@
 -r ./requirements.test.txt
 -r ./requirements.build.txt
 -r ./requirements.docs.txt
+pre-commit>=4.0.1,<5.0.0
 jupyterlab>=4.2.5,<5.0.0


### PR DESCRIPTION
Exclude the pre-commit configuration file from the package manifest and add the pre-commit dependency to the development requirements.