### PR TITLE
:broom: Remove commented-out version check step from build workflow

### DIFF
--- a/.github/workflows/2.build-publish.yml
+++ b/.github/workflows/2.build-publish.yml
@@ -18,9 +18,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
-      # - name: Check version
-      #   run: |
-      #     echo "$(./scripts/get-version.sh)"
       - name: Set up Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
This pull request makes a minor update to the `.github/workflows/2.build-publish.yml` workflow file, removing commented-out code related to checking the version in the build process. No functional changes have been introduced.