### PR TITLE
:broom: Remove version check step from build workflow

### DIFF
--- a/.github/workflows/2.build-publish.yml
+++ b/.github/workflows/2.build-publish.yml
@@ -18,9 +18,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
-      - name: Check version
-        run: |
-          echo "$(./scripts/get-version.sh)"
       - name: Set up Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
This pull request makes a minor update to the build and publish workflow configuration by removing a step that checked the version during the build process.

* Removed the "Check version" step from the `jobs:` section in `.github/workflows/2.build-publish.yml`.